### PR TITLE
Disable Rack::Protection on stub servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+** 0.22.3 **
+
+Breaking:
+* Stub servers no longer use the default protection provided by `Sinatra` and `Rack::Protection` (i.e. `JsonCsrf`, `HttpOrigin`, `RemoteToken`, etc).
+  * If the stubbed server uses those security features, they should be emulated by the `Configurer` when matching incoming requests.
+
 ** 0.22.2 **
 
 Fix:

--- a/lib/http_stub/server/application.rb
+++ b/lib/http_stub/server/application.rb
@@ -4,6 +4,7 @@ module HttpStub
     class Application < Sinatra::Base
 
       set :root, File.dirname(__FILE__)
+      disable :protection
 
       register Sinatra::Partial
 

--- a/spec/lib/http_stub/server/application_spec.rb
+++ b/spec/lib/http_stub/server/application_spec.rb
@@ -24,6 +24,10 @@ describe HttpStub::Server::Application do
     allow(HttpStub::Server::ResponsePipeline).to receive(:new).and_return(response_pipeline)
   end
 
+  it "disables all standard security features provided by Rack::Protection" do
+    expect(app.settings.protection).to eq false
+  end
+
   context "when the diagnostics landing page is retrieved" do
 
     subject { get "/http_stub" }


### PR DESCRIPTION
By default, stubs created with http_stub use the default `Rack::Protection` settings (example: enforcing JSON CSRF, same source domain on XHRs, etc). This shouldn't be the case: stubs should be permissive about requests it accepts and then use specific matchers to ensure that required parameters, headers, etc. are passed in.