### PR TITLE
Feature/same page activations

### DIFF
--- a/lib/http_stub/server/response.rb
+++ b/lib/http_stub/server/response.rb
@@ -4,11 +4,16 @@ module HttpStub
     class Response
 
       def self.success(headers={})
-        HttpStub::Server::Stub::Response::Text.new("status" => 200, "headers" => headers, "body" => "OK")
+        HttpStub::Server::Stub::Response::Text.new(
+          "status"  => 200,
+          "headers" => headers,
+          "body"    => '{"result": "OK"}')
       end
 
       SUCCESS   = success.freeze
-      NOT_FOUND = HttpStub::Server::Stub::Response::Text.new("status" => 404, "body" => "NOT FOUND").freeze
+      NOT_FOUND = HttpStub::Server::Stub::Response::Text.new(
+        "status"  => 404,
+        "body"    => '{"result": "NOT FOUND"}').freeze
       EMPTY     = HttpStub::Server::Stub::Response::Text.new.freeze
 
     end

--- a/lib/http_stub/server/views/_activate_scenario.haml
+++ b/lib/http_stub/server/views/_activate_scenario.haml
@@ -1,10 +1,37 @@
-%form{ id: :activate_scenario_form, action: "scenarios/activate", method: "POST" }
-  %input{ id: :activated_scenario_name, name: :name, type: :hidden, value: "" }
 :javascript
   $(window).load(function() {
     $("a.activate_scenario").on("click", function(event) {
       event.preventDefault();
-      $("#activated_scenario_name").val($(event.target).data("name"));
-      $("#activate_scenario_form").submit();
+      var button = $(event.target)
+      button.prop("disabled", true);
+      $.post(
+        "scenarios/activate",
+        {name: button.data("name")},
+        function(){
+          console.log("success");
+          button
+            .html("Activated")
+            .css("color", "green");
+          setTimeout(function(){
+            button
+              .html("Activate")
+              .css("color", "inherit");
+          }, 3000);
+        })
+        .fail(function(){
+          console.log("failure");
+          button
+            .html("Failed")
+            .css("color", "red");
+          setTimeout(function(){
+            button
+              .html("Activate")
+              .css("color", "inherit");
+          }, 3000);
+        })
+        .always(function(data){
+          console.log(data);
+          button.prop("disabled", false);
+        });
     });
   });

--- a/spec/lib/http_stub/server/response_spec.rb
+++ b/spec/lib/http_stub/server/response_spec.rb
@@ -7,7 +7,7 @@ describe HttpStub::Server::Response do
     end
 
     it "has a body containing OK to visually indicate success to those interacting via a browser" do
-      expect(subject.body).to match(/OK/)
+      expect(subject.body).to match(/{"result": "OK"}/)
     end
 
   end
@@ -49,7 +49,7 @@ describe HttpStub::Server::Response do
     end
 
     it "has a body containing NOT FOUND to visually indicate the response to those interacting via a browser" do
-      expect(subject.body).to match(/NOT FOUND/)
+      expect(subject.body).to match(/{"result": "NOT FOUND"}/)
     end
 
   end

--- a/spec/lib/http_stub/server/stub/stub_spec.rb
+++ b/spec/lib/http_stub/server/stub/stub_spec.rb
@@ -205,7 +205,7 @@ describe HttpStub::Server::Stub::Stub do
 
   end
 
-  describe "#repsonse_for" do
+  describe "#response_for" do
 
     let(:request) { instance_double(HttpStub::Server::Request::Request) }
 


### PR DESCRIPTION
Implementation for #14 

- Shows "Activated" in green on success
- Shows "Failed" in red on failure
- Server returns JSON instead of plain text
