### PR TITLE
Update Vulnerable Dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
     powerpack (0.1.1)
     public_suffix (3.0.1)
     rack (1.6.8)
-    rack-protection (1.5.3)
+    rack-protection (1.5.5)
       rack
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
@@ -118,7 +118,7 @@ GEM
       tilt (>= 1.3, < 3)
     sinatra-partial (1.0.1)
       sinatra (>= 1.4)
-    sys-proctable (1.0.0-universal-aix5)
+    sys-proctable (1.0.0-universal-aix-5)
     sys-proctree (0.0.10)
       sys-proctable (= 1.0.0)
     temple (0.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,14 +52,14 @@ GEM
     minitest (5.10.3)
     multi_json (1.12.2)
     multi_xml (0.6.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.3)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.0)
     parser (2.4.0.2)
       ast (~> 2.3)
     powerpack (0.1.1)
     public_suffix (3.0.1)
-    rack (1.6.8)
+    rack (1.6.10)
     rack-protection (1.5.5)
       rack
     rack-test (0.7.0)
@@ -148,4 +148,4 @@ DEPENDENCIES
   wait_until (~> 0.3)
 
 BUNDLED WITH
-   1.16.0
+   1.16.2


### PR DESCRIPTION
`nokogiri` and `rack-protection` were both flagged as having known vulnerabilities.

This update should bring them both into safer versions of those dependencies.